### PR TITLE
updated packages, handle exceptions thrown by websocket4net open method

### DIFF
--- a/Pusher.Connections.Net/Pusher.Connections.Net.csproj
+++ b/Pusher.Connections.Net/Pusher.Connections.Net.csproj
@@ -35,8 +35,9 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="WebSocket4Net">
-      <HintPath>..\packages\WebSocket4Net.0.8\lib\net40\WebSocket4Net.dll</HintPath>
+    <Reference Include="WebSocket4Net, Version=0.14.1.0, Culture=neutral, PublicKeyToken=eb4e154b696bf72a, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebSocket4Net.0.14.1\lib\net45\WebSocket4Net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -45,13 +46,15 @@
     <Compile Include="WebSocketConnectionFactory.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Pusher\Pusher.csproj">
       <Project>{ff212bec-10ac-49ec-9e57-164cd1cad02e}</Project>
       <Name>Pusher</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Pusher.Connections.Net/WebSocketConnection.cs
+++ b/Pusher.Connections.Net/WebSocketConnection.cs
@@ -6,136 +6,132 @@ using DataReceivedEventArgs = Pusher.Events.DataReceivedEventArgs;
 
 namespace Pusher.Connections.Net
 {
-	public class WebSocketConnection : IConnection
-	{
-		private WebSocket _socket;
-		private readonly Uri _endpoint;
-		private ConnectionState _connectionState;
+    public class WebSocketConnection : IConnection
+    {
+        private WebSocket _socket;
+        private readonly Uri _endpoint;
+        private ConnectionState _connectionState;
 
-		public WebSocketConnection(Uri endpoint)
-		{
-			_endpoint = endpoint;
-			SetupSocket();
-		}
+        public WebSocketConnection(Uri endpoint)
+        {
+            _endpoint = endpoint;
+            SetupSocket();
+        }
 
-		private void SetupSocket()
-		{
-			_socket = new WebSocket(_endpoint.ToString());
-			_socket.Closed += OnSocketClosed;
-			_socket.MessageReceived += OnMessageReceived;
-		}
+        private void SetupSocket()
+        {
+            _socket = new WebSocket(_endpoint.ToString());
+            _socket.Closed += OnSocketClosed;
+            _socket.MessageReceived += OnMessageReceived;
+        }
 
-		private async void OnMessageReceived(object sender, MessageReceivedEventArgs args)
-		{
-			if (OnData == null) return;
+        private async void OnMessageReceived(object sender, MessageReceivedEventArgs args)
+        {
+            if (OnData == null) return;
 
-			var exceptionOccured = false;
-			try
-			{
-				var text = args.Message;
-				OnData(sender, new DataReceivedEventArgs { TextData = text });
-			}
-			catch (Exception)
-			{
-				exceptionOccured = true;
-			}
-			// cannot await in catch
-			if (exceptionOccured)
-			{
-				_connectionState = ConnectionState.Failed;
-				try
-				{
-					await Reconnect();
-				}
-				catch (Exception e)
-				{
-					Error(e);
-				}
-			}
-		}
+            var exceptionOccured = false;
+            try
+            {
+                var text = args.Message;
+                OnData(sender, new DataReceivedEventArgs { TextData = text });
+            }
+            catch (Exception)
+            {
+                exceptionOccured = true;
+            }
+            // cannot await in catch
+            if (exceptionOccured)
+            {
+                _connectionState = ConnectionState.Failed;
+                try
+                {
+                    await Reconnect();
+                }
+                catch (Exception e)
+                {
+                    Error(e);
+                }
+            }
+        }
 
-		private async Task Reconnect()
-		{
-			if (_connectionState == ConnectionState.Connecting || _connectionState == ConnectionState.Connected) return;
+        private async Task Reconnect()
+        {
+            if (_connectionState == ConnectionState.Connecting || _connectionState == ConnectionState.Connected) return;
 
-			SetupSocket();
-			await Open();
-		}
+            SetupSocket();
+            await Open();
+        }
 
-		private async void OnSocketClosed(object sender, EventArgs args)
-		{
-			if (_connectionState != ConnectionState.Disconnecting)
-			{
-				_connectionState = ConnectionState.Failed;
-				try
-				{
-					await Reconnect();
-				}
-				catch (Exception e)
-				{
-					Error(e);
-					return;
-				}
-			}
-			_connectionState = ConnectionState.Disconnected;
-			if (OnClose != null) OnClose(sender, new EventArgs());
-		}
+        private async void OnSocketClosed(object sender, EventArgs args)
+        {
+            if (_connectionState != ConnectionState.Disconnecting)
+            {
+                _connectionState = ConnectionState.Failed;
+                try
+                {
+                    await Reconnect();
+                }
+                catch (Exception e)
+                {
+                    Error(e);
+                    return;
+                }
+            }
+            _connectionState = ConnectionState.Disconnected;
+            if (OnClose != null) OnClose(sender, new EventArgs());
+        }
 
-		#region Implementation of IConnection
+        #region Implementation of IConnection
 
-		public void Close()
-		{
-			_connectionState = ConnectionState.Disconnecting;
-			_socket.Close(1000, "Close requested");
-			_connectionState = ConnectionState.Disconnected;
-		}
+        public void Close()
+        {
+            _connectionState = ConnectionState.Disconnecting;
+            _socket.Close(1000, "Close requested");
+            _connectionState = ConnectionState.Disconnected;
+        }
 
-		public async Task Open()
-		{
-			try
-			{
-				if (_connectionState == ConnectionState.Connected)
-				{
-					Close();
-					SetupSocket();
-				}
+        public async Task Open()
+        {
+            if (_connectionState == ConnectionState.Connected)
+            {
+                Close();
+                SetupSocket();
+            }
 
-				_connectionState = ConnectionState.Connecting;
-				_socket.Open();
+            _connectionState = ConnectionState.Connecting;
+            _socket.Open();
 
-				_connectionState = ConnectionState.Connected;
-				if (OnOpen != null)
-				{
-					OnOpen(this, new EventArgs());
-				}
-			}
-			catch { }
-		}
+            _connectionState = ConnectionState.Connected;
+            if (OnOpen != null)
+            {
+                OnOpen(this, new EventArgs());
+            }
+        }
 
-		public async Task SendMessage(string data)
-		{
-			if (_connectionState != ConnectionState.Connected)
-			{
-				await Open();
-			}
+        public async Task SendMessage(string data)
+        {
+            if (_connectionState != ConnectionState.Connected)
+            {
+                await Open();
+            }
 
-			_socket.Send(data);
-		}
+            _socket.Send(data);
+        }
 
-		/// <summary>
-		/// Triggered whenever an error occurs whenever we cannot raise an exception (because it could not be caught).
-		/// </summary>
-		private void Error(Exception e)
-		{
-			if (OnError == null) return;
-			OnError(this, new ExceptionEventArgs { Exception = e });
-		}
+        /// <summary>
+        /// Triggered whenever an error occurs whenever we cannot raise an exception (because it could not be caught).
+        /// </summary>
+        private void Error(Exception e)
+        {
+            if (OnError == null) return;
+            OnError(this, new ExceptionEventArgs { Exception = e });
+        }
 
-		public event EventHandler<ExceptionEventArgs> OnError;
-		public event EventHandler<EventArgs> OnClose;
-		public event EventHandler<EventArgs> OnOpen;
-		public event EventHandler<DataReceivedEventArgs> OnData;
+        public event EventHandler<ExceptionEventArgs> OnError;
+        public event EventHandler<EventArgs> OnClose;
+        public event EventHandler<EventArgs> OnOpen;
+        public event EventHandler<DataReceivedEventArgs> OnData;
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/Pusher.Connections.Net/WebSocketConnection.cs
+++ b/Pusher.Connections.Net/WebSocketConnection.cs
@@ -6,132 +6,136 @@ using DataReceivedEventArgs = Pusher.Events.DataReceivedEventArgs;
 
 namespace Pusher.Connections.Net
 {
-    public class WebSocketConnection : IConnection
-    {
-        private WebSocket _socket;
-        private readonly Uri _endpoint;
-        private ConnectionState _connectionState;
+	public class WebSocketConnection : IConnection
+	{
+		private WebSocket _socket;
+		private readonly Uri _endpoint;
+		private ConnectionState _connectionState;
 
-        public WebSocketConnection(Uri endpoint)
-        {
-            _endpoint = endpoint;
-            SetupSocket();
-        }
+		public WebSocketConnection(Uri endpoint)
+		{
+			_endpoint = endpoint;
+			SetupSocket();
+		}
 
-        private void SetupSocket()
-        {
-            _socket = new WebSocket(_endpoint.ToString());
-            _socket.Closed += OnSocketClosed;
-            _socket.MessageReceived += OnMessageReceived;
-        }
+		private void SetupSocket()
+		{
+			_socket = new WebSocket(_endpoint.ToString());
+			_socket.Closed += OnSocketClosed;
+			_socket.MessageReceived += OnMessageReceived;
+		}
 
-        private async void OnMessageReceived(object sender, MessageReceivedEventArgs args)
-        {
-            if (OnData == null) return;
+		private async void OnMessageReceived(object sender, MessageReceivedEventArgs args)
+		{
+			if (OnData == null) return;
 
-            var exceptionOccured = false;
-            try
-            {
-                var text = args.Message;
-                OnData(sender, new DataReceivedEventArgs { TextData = text });
-            }
-            catch (Exception)
-            {
-                exceptionOccured = true;
-            }
-            // cannot await in catch
-            if (exceptionOccured)
-            {
-                _connectionState = ConnectionState.Failed;
-                try
-                {
-                    await Reconnect();
-                }
-                catch (Exception e)
-                {
-                    Error(e);
-                }
-            }
-        }
+			var exceptionOccured = false;
+			try
+			{
+				var text = args.Message;
+				OnData(sender, new DataReceivedEventArgs { TextData = text });
+			}
+			catch (Exception)
+			{
+				exceptionOccured = true;
+			}
+			// cannot await in catch
+			if (exceptionOccured)
+			{
+				_connectionState = ConnectionState.Failed;
+				try
+				{
+					await Reconnect();
+				}
+				catch (Exception e)
+				{
+					Error(e);
+				}
+			}
+		}
 
-        private async Task Reconnect()
-        {
-            if (_connectionState == ConnectionState.Connecting || _connectionState == ConnectionState.Connected) return;
+		private async Task Reconnect()
+		{
+			if (_connectionState == ConnectionState.Connecting || _connectionState == ConnectionState.Connected) return;
 
-            SetupSocket();
-            await Open();
-        }
+			SetupSocket();
+			await Open();
+		}
 
-        private async void OnSocketClosed(object sender, EventArgs args)
-        {
-            if (_connectionState != ConnectionState.Disconnecting)
-            {
-                _connectionState = ConnectionState.Failed;
-                try
-                {
-                    await Reconnect();
-                }
-                catch (Exception e)
-                {
-                    Error(e);
-                    return;
-                }
-            }
-            _connectionState = ConnectionState.Disconnected;
-            if (OnClose != null) OnClose(sender, new EventArgs());
-        }
+		private async void OnSocketClosed(object sender, EventArgs args)
+		{
+			if (_connectionState != ConnectionState.Disconnecting)
+			{
+				_connectionState = ConnectionState.Failed;
+				try
+				{
+					await Reconnect();
+				}
+				catch (Exception e)
+				{
+					Error(e);
+					return;
+				}
+			}
+			_connectionState = ConnectionState.Disconnected;
+			if (OnClose != null) OnClose(sender, new EventArgs());
+		}
 
-        #region Implementation of IConnection
+		#region Implementation of IConnection
 
-        public void Close()
-        {
-            _connectionState = ConnectionState.Disconnecting;
-            _socket.Close(1000, "Close requested");
-            _connectionState = ConnectionState.Disconnected;
-        }
+		public void Close()
+		{
+			_connectionState = ConnectionState.Disconnecting;
+			_socket.Close(1000, "Close requested");
+			_connectionState = ConnectionState.Disconnected;
+		}
 
-        public async Task Open()
-        {
-            if (_connectionState == ConnectionState.Connected)
-            {
-                Close();
-                SetupSocket();
-            }
+		public async Task Open()
+		{
+			try
+			{
+				if (_connectionState == ConnectionState.Connected)
+				{
+					Close();
+					SetupSocket();
+				}
 
-            _connectionState = ConnectionState.Connecting;
-            _socket.Open();
-            
-            _connectionState = ConnectionState.Connected;
-            if (OnOpen != null)
-            {
-                OnOpen(this, new EventArgs());
-            }
-        }
+				_connectionState = ConnectionState.Connecting;
+				_socket.Open();
 
-        public async Task SendMessage(string data)
-        {
-            if (_connectionState != ConnectionState.Connected)
-            {
-                await Open();
-            }
+				_connectionState = ConnectionState.Connected;
+				if (OnOpen != null)
+				{
+					OnOpen(this, new EventArgs());
+				}
+			}
+			catch { }
+		}
 
-            _socket.Send(data);
-        }
+		public async Task SendMessage(string data)
+		{
+			if (_connectionState != ConnectionState.Connected)
+			{
+				await Open();
+			}
 
-        /// <summary>
-        /// Triggered whenever an error occurs whenever we cannot raise an exception (because it could not be caught).
-        /// </summary>
-        private void Error(Exception e)
-        {
-            if (OnError == null) return;
-            OnError(this, new ExceptionEventArgs { Exception = e });
-        }
+			_socket.Send(data);
+		}
 
-        public event EventHandler<ExceptionEventArgs> OnError;
-        public event EventHandler<EventArgs> OnClose;
-        public event EventHandler<EventArgs> OnOpen;
-        public event EventHandler<DataReceivedEventArgs> OnData;
+		/// <summary>
+		/// Triggered whenever an error occurs whenever we cannot raise an exception (because it could not be caught).
+		/// </summary>
+		private void Error(Exception e)
+		{
+			if (OnError == null) return;
+			OnError(this, new ExceptionEventArgs { Exception = e });
+		}
 
-        #endregion
-    }
+		public event EventHandler<ExceptionEventArgs> OnError;
+		public event EventHandler<EventArgs> OnClose;
+		public event EventHandler<EventArgs> OnOpen;
+		public event EventHandler<DataReceivedEventArgs> OnData;
+
+		#endregion
+	}
 }

--- a/Pusher.Connections.Net/WebSocketConnection.cs
+++ b/Pusher.Connections.Net/WebSocketConnection.cs
@@ -92,20 +92,24 @@ namespace Pusher.Connections.Net
 
         public async Task Open()
         {
-            if (_connectionState == ConnectionState.Connected)
+            try
             {
-                Close();
-                SetupSocket();
-            }
+                if (_connectionState == ConnectionState.Connected)
+                {
+                    Close();
+                    SetupSocket();
+                }
 
-            _connectionState = ConnectionState.Connecting;
-            _socket.Open();
+                _connectionState = ConnectionState.Connecting;
+                _socket.Open();
 
-            _connectionState = ConnectionState.Connected;
-            if (OnOpen != null)
-            {
-                OnOpen(this, new EventArgs());
+                _connectionState = ConnectionState.Connected;
+                if (OnOpen != null)
+                {
+                    OnOpen(this, new EventArgs());
+                }
             }
+            catch { }
         }
 
         public async Task SendMessage(string data)

--- a/Pusher.Connections.Net/packages.config
+++ b/Pusher.Connections.Net/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="WebSocket4Net" version="0.8" targetFramework="net45" />
+  <package id="WebSocket4Net" version="0.14.1" targetFramework="net45" />
 </packages>

--- a/Pusher/Pusher.csproj
+++ b/Pusher/Pusher.csproj
@@ -16,6 +16,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -68,36 +70,47 @@
     <Compile Include="WebServiceScheme.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Threading.Tasks">
-      <HintPath>..\..\Beat\packages\Microsoft.Bcl.Async.1.0.165\lib\portable-net40+sl4+win8+wp71\Microsoft.Threading.Tasks.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net40+sl4+win8+wp71+wpa81\Microsoft.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
-      <HintPath>..\..\Beat\packages\Microsoft.Bcl.Async.1.0.165\lib\portable-net40+sl4+win8+wp71\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\portable-net40+sl4+win8+wp71+wpa81\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\Beat\packages\Newtonsoft.Json.6.0.1\lib\portable-net40+sl5+wp80+win8+monotouch+monoandroid\Newtonsoft.Json.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\portable-net40+sl5+win8+wp8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO">
-      <HintPath>..\..\Beat\packages\Microsoft.Bcl.1.1.6\lib\portable-net40+sl5+win8+wp8\System.IO.dll</HintPath>
+    <Reference Include="System.IO, Version=1.5.11.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+sl5+win8+wp8+wpa81\System.IO.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\Beat\packages\Microsoft.Bcl.1.1.6\lib\portable-net40+sl5+win8+wp8\System.Runtime.dll</HintPath>
+    <Reference Include="System.Runtime, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+sl5+win8+wp8+wpa81\System.Runtime.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\..\Beat\packages\Microsoft.Bcl.1.1.6\lib\portable-net40+sl5+win8+wp8\System.Threading.Tasks.dll</HintPath>
+    <Reference Include="System.Threading.Tasks, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\portable-net40+sl5+win8+wp8+wpa81\System.Threading.Tasks.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Import Project="..\..\Beat\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\Beat\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
-    <Error Condition="!Exists('..\..\Beat\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
-    <Error Condition="Exists('..\..\Beat\packages\Microsoft.Bcl.Build.1.0.13\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Pusher/app.config
+++ b/Pusher/app.config
@@ -9,11 +9,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.6.0" newVersion="2.6.6.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.6.6.0" newVersion="2.6.6.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.10.0" newVersion="2.6.10.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Pusher/packages.config
+++ b/Pusher/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.6" targetFramework="portable-net45+sl50+win" />
-  <package id="Microsoft.Bcl.Async" version="1.0.165" targetFramework="portable-net45+sl50+win" />
-  <package id="Microsoft.Bcl.Build" version="1.0.13" targetFramework="portable-net45+sl50+win" />
-  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="portable-net45+sl50+win" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="portable40-net45+sl5+win8" />
+  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="portable40-net45+sl5+win8" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable40-net45+sl5+win8" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="portable40-net45+sl5+win8" />
 </packages>


### PR DESCRIPTION
Updated all packages in `Pusher` portable library and `Pusher.Connections.NET` project including `WebSocket4Net`

Added exception handling to `WebSocketConnection.cs` in the `Open` method. This issue was discussed in issue #4. I had attempted to resolve the issue in my own project but the SuperSocket.ClientEngine error continues to not be handled. Hoping this change will resolve the problems I'm seeing.